### PR TITLE
fix: force add data/latest.json in GitHub Actions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Commit and push if changes
         run: |
-          git add data/
+          git add -f data/latest.json
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
## Problem
The GitHub Actions workflow cannot commit `data/latest.json` because it's in `.gitignore`.

## Solution
Use `git add -f data/latest.json` to force add the file even though it's ignored.

## Result
- ✅ Local developers: file remains ignored (won't commit accidentally)
- ✅ GitHub Actions: can commit generated file daily

## Testing
After merge, manually run the workflow to verify it commits the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)