### PR TITLE
fix: update Reddit scraper User-Agent to avoid 403 blocks

### DIFF
--- a/scrapers/reddit.py
+++ b/scrapers/reddit.py
@@ -39,7 +39,8 @@ def scrape_reddit() -> List[Dict[str, Any]]:
     feed_urls = config.get('feed_urls', [])
 
     headers = {
-        'User-Agent': 'AIRadar/1.0'
+        'User-Agent': 'web:ai-radar:v1.0 (by /u/ai-radar-bot)',
+        'Accept': 'application/json',
     }
 
     for feed_url in feed_urls:


### PR DESCRIPTION
## Summary
- Updates Reddit scraper `User-Agent` header to follow Reddit's required `platform:app:version (by /u/username)` format
- Fixes 403 Blocked errors from all Reddit API requests in the daily workflow

## Test plan
- [x] Verified locally — Reddit API returns 200 with the new User-Agent
- [ ] Trigger daily workflow and confirm Reddit items are collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)